### PR TITLE
Add a benchmark for moodycamel::ReaderWriterQueue

### DIFF
--- a/moodycamel.h
+++ b/moodycamel.h
@@ -5,6 +5,7 @@
 // Copyright (c) 2019 Maxim Egorushkin. MIT License. See the full licence in file LICENSE.
 
 #include <concurrentqueue/concurrentqueue.h>
+#include <readerwriterqueue/readerwriterqueue.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -16,6 +17,25 @@ template<class T, unsigned Capacity>
 struct MoodyCamelQueue : moodycamel::ConcurrentQueue<T> {
     MoodyCamelQueue()
         : moodycamel::ConcurrentQueue<T>(Capacity)
+    {}
+
+    void push(T element) {
+        while(!this->try_enqueue(element))
+            ;
+    }
+
+    T pop() {
+        T element;
+        while(!this->try_dequeue(element))
+            ;
+        return element;
+    }
+};
+
+template<class T, unsigned Capacity>
+struct MoodyCamelReaderWriterQueue : moodycamel::ReaderWriterQueue<T> {
+    MoodyCamelReaderWriterQueue()
+        : moodycamel::ReaderWriterQueue<T>(Capacity)
     {}
 
     void push(T element) {


### PR DESCRIPTION
which, at least on my machine, rolls all over boost::lockfree::spsc_queue