### PR TITLE
[PATCH] Update RISC-V support to use real pause

### DIFF
--- a/include/atomic_queue/defs.h
+++ b/include/atomic_queue/defs.h
@@ -51,7 +51,7 @@ static inline void spin_loop_pause() noexcept {} // TODO: Find the right instruc
 namespace atomic_queue {
 constexpr int CACHE_LINE_SIZE = 64;
 static inline void spin_loop_pause() noexcept {
-    asm volatile ("nop");
+    asm volatile (".insn i 0x0F, 0, x0, x0, 0x010");
 }
 } // namespace atomic_queue
 #else


### PR DESCRIPTION
See also:

`rust-lang/stdarch`: https://github.com/rust-lang/stdarch/blob/7a41576c3f540ea96f70e6117e7ac3218c9b4367/crates/core_arch/src/riscv_shared/mod.rs#L10-L12

Explanation of `pause`, `fence w,0` and `.insn`: https://blog.jiejiss.com/Rust-is-incompatible-with-LLVM-at-least-partially/#pause-fence-and-.insn

Note that this compiles on gcc 11.2.0 but not clang 13.0.1, and will compile on clang 14.0.0 (related commit: https://github.com/llvm/llvm-project/commit/283879793dc787225992496587581ec77b6b0610, tested on clang 14.0.0-rc1)