### PR TITLE
Add unsafe AtomicQueueB2::data() accessor for bulk reads

### DIFF
--- a/include/atomic_queue/atomic_queue.h
+++ b/include/atomic_queue/atomic_queue.h
@@ -597,6 +597,10 @@ public:
     friend void swap(AtomicQueueB2& a, AtomicQueueB2& b) noexcept {
         a.swap(b);
     }
+
+	[[nodiscard]] const T* data() const noexcept {
+		return elements_;
+	}
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As the title mentions, this allows accessing the internal data pointer of a dynamic atomic queue for bulk read operations. Making sure the call is safe should be up to the implementor in my opinion to reduce overhead as much as possible.