### PR TITLE
Fix typo in benchmarks.html

### DIFF
--- a/html/benchmarks.html
+++ b/html/benchmarks.html
@@ -20,7 +20,7 @@
     <script src="theme.js"></script>
     <script src="benchmarks.js"></script>
     <meta charset="utf-8">
-    <title>Scalaibilty and Latency Benchmarks</title>
+    <title>Scalability and Latency Benchmarks</title>
   </head>
   <body>
     <h1 class="view-toggle">Scalability Benchmark</h1>


### PR DESCRIPTION
I kept noticing this when I had the page open in a browser tab on my phone :slightly_smiling_face: 