### PR TITLE
Add CMake Support

### DIFF
--- a/.github/workflows/cmake-gcc-clang.yml
+++ b/.github/workflows/cmake-gcc-clang.yml
@@ -1,6 +1,6 @@
 # This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
-name: CMake on multiple platforms
+name: CMake with GCC / Clang
 
 on:
   push:
@@ -58,26 +58,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get install -y libboost-all-dev
-    - name: Install boost via vcpkg
-      if: matrix.os == 'windows-latest'
-      run: |
-          vcpkg integrate install
-          vcpkg.exe install boost-test --triplet x64-windows
-
-    - name: Configure CMake Windows
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      if: matrix.os == 'windows-latest'
-      run: >
-        cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DATOMIC_QUEUE_BUILD_TESTS=ON
-        -DATOMIC_QUEUE_BUILD_EXAMPLES=ON
-        -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\scripts\buildsystems\vcpkg.cmake
-        -DVCPKG_TARGET_TRIPLET=x64-windows
-        -S ${{ github.workspace }}
 
     - name: Configure CMake Ubuntu
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-gcc-clang.yml
+++ b/.github/workflows/cmake-gcc-clang.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch
 
 jobs:
   build:

--- a/.github/workflows/cmake-gcc-clang.yml
+++ b/.github/workflows/cmake-gcc-clang.yml
@@ -4,10 +4,9 @@ name: CMake with GCC / Clang
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "CMake-support"]
   pull_request:
     branches: [ "master" ]
-  workflow_dispatch
 
 jobs:
   build:
@@ -26,11 +25,8 @@ jobs:
       matrix:
         os: [ubuntu-latest] # windows-latest
         build_type: [Release]
-        c_compiler: [gcc, clang, cl]
+        c_compiler: [gcc, clang]
         include:
-          - os: windows-latest
-            c_compiler: cl
-            cpp_compiler: cl
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
@@ -38,10 +34,6 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
         exclude:
-          - os: windows-latest
-            c_compiler: gcc
-          - os: windows-latest
-            c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,103 @@
+# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      # Set up a matrix to run the following 3 configurations:
+      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
+      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      #
+      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
+      matrix:
+        os: [ubuntu-latest] # windows-latest
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: ubuntu-latest
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Install boost
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get install -y libboost-all-dev
+    - name: Install boost via vcpkg
+      if: matrix.os == 'windows-latest'
+      run: |
+          vcpkg integrate install
+          vcpkg.exe install boost-test --triplet x64-windows
+
+    - name: Configure CMake Windows
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      if: matrix.os == 'windows-latest'
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DATOMIC_QUEUE_BUILD_TESTS=ON
+        -DATOMIC_QUEUE_BUILD_EXAMPLES=ON
+        -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\scripts\buildsystems\vcpkg.cmake
+        -DVCPKG_TARGET_TRIPLET=x64-windows
+        -S ${{ github.workspace }}
+
+    - name: Configure CMake Ubuntu
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      if: matrix.os == 'ubuntu-latest'
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DATOMIC_QUEUE_BUILD_TESTS=ON
+        -DATOMIC_QUEUE_BUILD_EXAMPLES=ON
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - name: Test
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest --build-config ${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+CMAKE_MINIMUM_REQUIRED( VERSION 3.25 )
+
+PROJECT(atomic_queue VERSION 1.5.0)
+
+OPTION( ATOMIC_QUEUE_BUILD_TESTS
+    "If the tests should be built."
+    OFF
+)
+
+OPTION( ATOMIC_QUEUE_BUILD_EXAMPLES
+    "If examples should be built."
+    OFF
+)
+
+if ( PROJECT_IS_TOP_LEVEL )
+    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD_REQUIRED)
+endif()
+
+add_subdirectory( include )
+
+if ( ATOMIC_QUEUE_BUILD_TESTS OR ATOMIC_QUEUE_BUILD_EXAMPLES)
+    add_subdirectory( src )
+endif()
+
+add_library(max0x7ba::atomic_queue ALIAS atomic_queue)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ endif()
 
 add_subdirectory( include )
 
+if ( ATOMIC_QUEUE_BUILD_TESTS )
+    enable_testing()
+endif()
+
 if ( ATOMIC_QUEUE_BUILD_TESTS OR ATOMIC_QUEUE_BUILD_EXAMPLES)
     add_subdirectory( src )
 endif()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,17 @@
+CMAKE_MINIMUM_REQUIRED( VERSION 3.25 )
+
+add_library(
+    atomic_queue
+    INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/atomic_queue.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/atomic_queue_mutex.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/barrier.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/defs.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/atomic_queue/spinlock.h
+)
+
+target_include_directories(
+    atomic_queue
+    INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,6 @@ if ( ATOMIC_QUEUE_BUILD_EXAMPLES )
 endif()
 
 if ( ATOMIC_QUEUE_BUILD_TESTS )
-    enable_testing()
     find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 
     add_executable(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,34 @@
+CMAKE_MINIMUM_REQUIRED( VERSION 3.25 )
+
+if ( ATOMIC_QUEUE_BUILD_EXAMPLES )
+    add_executable(
+        atomic_queue_example
+        ${CMAKE_CURRENT_SOURCE_DIR}/example.cc
+    )
+
+    target_link_libraries(
+        atomic_queue_example
+        atomic_queue
+    )
+endif()
+
+if ( ATOMIC_QUEUE_BUILD_TESTS )
+    enable_testing()
+    find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+
+    add_executable(
+        atomic_queue_tests
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests.cc
+    )
+
+    target_link_libraries(
+        atomic_queue_tests
+        atomic_queue
+        Boost::unit_test_framework
+    )
+
+    add_test(
+        NAME atomic_queue_tests
+        COMMAND atomic_queue_tests
+    )
+endif()


### PR DESCRIPTION
Added basic CMake support
- interface (header only) library for atomic_queue
- option to build samples
- option to build tests + CTest support
- gcc/clang linux cmake build

Because of the way dependencies are set up in benchmarking I did not implement benchmark target. Those could be implemented with either cmake's install + find_package or with FetchContent if respective libraries use CMake and are small enough. 

Boost, which is used by the test target, is found using find_opackage. This causes some issues on Windows - the easiest way to get it to work on windows is by using vcpkg. To mitigate it, it would be the best to replace boost-test with google-test, which can be easily downloaded and installed per-repo with fetch_content.