### PR TITLE
Allocator aware constructors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integrations
 
 on:
   push:
-    branches: [ master , allocator-aware-constructors ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integrations
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master , allocator-aware-constructors ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Modified constructors of AtomicQueueB and AtomicQueue2B to accept constructor (default construction as default value - same design philosophy as in STL). 
Written tests to test allocator semantics (move-semantics were implemented before, just the constructors were missing). Tests to check if the custom allocator is used properly should be written.