### PR TITLE
Make library target visible to downstream clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,5 +26,3 @@ endif()
 if ( ATOMIC_QUEUE_BUILD_TESTS OR ATOMIC_QUEUE_BUILD_EXAMPLES)
     add_subdirectory( src )
 endif()
-
-add_library(max0x7ba::atomic_queue ALIAS atomic_queue)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,5 +1,7 @@
 CMAKE_MINIMUM_REQUIRED( VERSION 3.25 )
 
+include(GNUInstallDirs)
+
 add_library(
     atomic_queue
     INTERFACE
@@ -11,7 +13,8 @@ add_library(
 )
 
 target_include_directories(
-    atomic_queue
+    ${PROJECT_NAME}
     INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )


### PR DESCRIPTION
Using the library with `FetchContent` successfully downloaded the library onto the `build/_deps` directory but all the `#include` statements yielded a compiler error because CMake wasn't including `atomic_queue` directory for the target. You can test this on this repo likeso:

```
FetchContent_Declare(
        atomic_queue
        GIT_REPOSITORY https://github.com/max0x7ba/atomic_queue.git
        GIT_TAG v1.6.1)
FetchContent_MakeAvailable(atomic_queue)

target_link_libraries(${PROJECT_NAME} PRIVATE atomic_queue)
```

And link to an executable that includes the library. It should fail to compile.

If you instead link against my fork's version, it will work:

```
FetchContent_Declare(
        atomic_queue
        GIT_REPOSITORY https://github.com/yaneury/atomic_queue.git
        GIT_TAG stable)
FetchContent_MakeAvailable(atomic_queue)
```