### PR TITLE
Fix -Wmissing-template-arg-list-after-template-kw issued by Clang 19

### DIFF
--- a/include/atomic_queue/atomic_queue.h
+++ b/include/atomic_queue/atomic_queue.h
@@ -404,13 +404,13 @@ class AtomicQueue2 : public AtomicQueueCommon<AtomicQueue2<T, SIZE, MINIMIZE_CON
 
     T do_pop(unsigned tail) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(tail % size_);
-        return Base::template do_pop_any(states_[index], elements_[index]);
+        return Base::do_pop_any(states_[index], elements_[index]);
     }
 
     template<class U>
     void do_push(U&& element, unsigned head) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(head % size_);
-        Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+        Base::do_push_any(std::forward<U>(element), states_[index], elements_[index]);
     }
 
 public:
@@ -535,13 +535,13 @@ class AtomicQueueB2 : private std::allocator_traits<A>::template rebind_alloc<un
 
     T do_pop(unsigned tail) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(tail & (size_ - 1));
-        return Base::template do_pop_any(states_[index], elements_[index]);
+        return Base::do_pop_any(states_[index], elements_[index]);
     }
 
     template<class U>
     void do_push(U&& element, unsigned head) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(head & (size_ - 1));
-        Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+        Base::do_push_any(std::forward<U>(element), states_[index], elements_[index]);
     }
 
     template<class U>


### PR DESCRIPTION
This warning is treated as error by default:
https://releases.llvm.org/19.1.0/tools/clang/docs/DiagnosticsReference.html#wmissing-template-arg-list-after-template-kw  
So build breaks for all library consumers even when `-Werror`, `-Wall`, etc. are not used.

STR:
```
$ CXX=clang++-19 CC=clang-19 cmake -B build -DATOMIC_QUEUE_BUILD_TESTS=yes &> /dev/null
$ cmake --build build
[  0%] Built target atomic_queue
[ 50%] Building CXX object src/CMakeFiles/atomic_queue_tests.dir/tests.cc.o
In file included from /tmp/atomic_queue/src/tests.cc:8:
/tmp/atomic_queue/include/atomic_queue/atomic_queue.h:407:31: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  407 |         return Base::template do_pop_any(states_[index], elements_[index]);
      |                               ^
/tmp/atomic_queue/include/atomic_queue/atomic_queue.h:413:24: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]                                                                                   
  413 |         Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
      |                        ^
/tmp/atomic_queue/include/atomic_queue/atomic_queue.h:538:31: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]                                                                                   
  538 |         return Base::template do_pop_any(states_[index], elements_[index]);
      |                               ^
/tmp/atomic_queue/include/atomic_queue/atomic_queue.h:544:24: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]                                                                                   
  544 |         Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
      |                        ^
4 errors generated.
```