### PR TITLE
Add support for loong64

### DIFF
--- a/include/atomic_queue/defs.h
+++ b/include/atomic_queue/defs.h
@@ -56,6 +56,14 @@ static inline void spin_loop_pause() noexcept {
     asm volatile (".insn i 0x0F, 0, x0, x0, 0x010");
 }
 } // namespace atomic_queue
+#elif defined(__loongarch__)
+namespace atomic_queue {
+constexpr int CACHE_LINE_SIZE = 64;
+static inline void spin_loop_pause() noexcept
+{
+    asm volatile("nop \n nop \n nop \n nop \n nop \n nop \n nop \n nop");
+}
+} // namespace atomic_queue
 #else
 #ifdef _MSC_VER
 #pragma message("Unknown CPU architecture. Using L1 cache line size of 64 bytes and no spinloop pause instruction.")


### PR DESCRIPTION
Similar to #38, adding support for loong64.

[LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.

This a successful [buildlog](https://gist.github.com/NakanoMiku39/4c234349920ea4fa7c26c443a425beba) for sfizz on a loong64 machine.

Thanks