### PR TITLE
meson: add option to disable tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 # Copyright (c) 2019 Maxim Egorushkin. MIT License. See the full licence in file LICENSE.
 
-# (rm -rf build; meson build; cd build; time ninja -v)
+# (rm -rf build; meson setup build; time ninja -C build -v)
 
 project(
   'atomic_queue', 'cpp',
@@ -8,35 +8,40 @@ project(
   default_options : ['cpp_std=gnu++14', 'buildtype=release', 'b_ndebug=if-release']
 )
 
-cxx = meson.get_compiler('cpp')
-dl = cxx.find_library('dl', required : true)
-threads = dependency('threads')
-unit_test_framework = dependency('boost', modules : ['unit_test_framework'])
-if get_option('benchmarks')
-  tbb = cxx.find_library('tbb', required : true)
-  xenium = declare_dependency(include_directories : '../xenium')
-  moodycamel = declare_dependency(include_directories : '../')
+threads_dep = dependency('threads')
+
+atomic_queue_dep = declare_dependency(include_directories : ['include'], dependencies : threads_dep)
+
+if get_option('tests')
+  unit_test_framework_dep = dependency('boost', modules : ['unit_test_framework'])
+
+  tests_exe = executable(
+    'tests',
+    'src/tests.cc',
+    dependencies : [atomic_queue_dep, unit_test_framework_dep],
+  )
+  test('tests', tests_exe)
+
+  example_exe = executable(
+    'example',
+    'src/example.cc',
+    dependencies : [atomic_queue_dep],
+  )
+  test('example', example_exe)
 endif
 
-atomic_queue = declare_dependency(include_directories : ['include'], dependencies : threads)
-
-tests_exe = executable(
-  'tests',
-  'src/tests.cc',
-  dependencies : [atomic_queue, unit_test_framework]
-)
-test('tests', tests_exe)
-
-example_exe = executable(
-  'example',
-  'src/example.cc',
-  dependencies : [atomic_queue]
-)
-
 if get_option('benchmarks')
-  benchmarks_exe = executable(
+  cxx = meson.get_compiler('cpp')
+  dl_dep = cxx.find_library('dl')
+  xenium_dep = declare_dependency(include_directories : '../xenium')
+  boost_dep = dependency('boost')
+  tbb_dep = cxx.find_library('tbb')
+  moodycamel_dep = declare_dependency(include_directories : '../')
+
+  executable(
     'benchmarks',
     ['src/benchmarks.cc', 'src/cpu_base_frequency.cc', 'src/huge_pages.cc'],
-    dependencies : [atomic_queue, xenium, moodycamel, tbb, dl]
+    include_directories : ['src'],
+    dependencies : [atomic_queue_dep, dl_dep, xenium_dep, boost_dep, tbb_dep, moodycamel_dep],
   )
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,4 @@
 option('benchmarks', type : 'boolean', value : true,
-       description : 'Do not build benchmarks; ignore their dependencies')
+       description : 'Build benchmarks (requires Boost, TBB, Xenium and moodycamel)')
+option('tests', type : 'boolean', value : true,
+       description : 'Build tests and example (requires Boost)')


### PR DESCRIPTION
This is a little facelift for the meson build file. It contains the following changes:

- Add an option to disable building the tests (enabled by default)
- Improve the options description
- Run the example as part of the tests (doesn't hurt)
- Add a missing Boost dependency for the benchmark
- Add a `_dep` suffix to all dependency objects for clarity
