### PR TITLE
remove unused header from test

### DIFF
--- a/src/tests.cc
+++ b/src/tests.cc
@@ -6,7 +6,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include "atomic_queue/atomic_queue.h"
-#include "atomic_queue/atomic_queue_mutex.h"
 #include "atomic_queue/barrier.h"
 
 #include <cstdint>


### PR DESCRIPTION
Removes an unused header from the test - since that header includes linux pthread, this should allow for compilation of the tests under MacOS and Windows.

For MacOS see https://github.com/mesonbuild/wrapdb/actions/runs/14694171914/job/41233568645