### PR TITLE
Fix Werror=sign-compare

### DIFF
--- a/include/atomic_queue/atomic_queue.h
+++ b/include/atomic_queue/atomic_queue.h
@@ -334,7 +334,7 @@ public:
     }
 
     bool was_full() const noexcept {
-        return was_size() >= static_cast<int>(static_cast<Derived const&>(*this).size_);
+        return was_size() >= capacity();
     }
 
     unsigned was_size() const noexcept {


### PR DESCRIPTION
On GCC with `-Werror=sign-compare`, using `atomic_queue` gives the following error:

```
../subprojects/atomic_queue-1.6.6/include/atomic_queue/atomic_queue.h:337:27: error: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Werror=sign-compare]
  337 |         return was_size() >= static_cast<int>(static_cast<Derived const&>(*this).size_);
      |                ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I don't see any good reason why the size should be cast to an integer. In fact, the second expression is just the capacity anyway, so let's use the capacity instead. Then both expressions use `unsigned` for a well defined comparison.