### PR TITLE
chore: add ubuntu arm to workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 4
 
 [Makefile]
 indent_style = tab
+
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -11,16 +11,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         cpp_compiler: [g++, clang++]
-        sanitize: [address ,undefined, thread]
+        sanitize: [address, undefined, thread]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Meson and Boost.Test
-        run: sudo apt-get --quiet --yes install meson libboost-test-dev
+        run: sudo apt-get install --yes -qq meson libboost-test-dev
 
       - name: Setup
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
     strategy:
       matrix:
         toolset: [gcc, clang]
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Boost.Test
-      run: sudo apt-get --quiet --yes install libboost-test-dev
+      run: sudo apt-get install --yes -qq libboost-test-dev
 
     - name: Environment variables
       run: make -r TOOLSET=${{ matrix.toolset }} env

--- a/.github/workflows/cmake-gcc-clang.yml
+++ b/.github/workflows/cmake-gcc-clang.yml
@@ -23,22 +23,14 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest] # windows-latest
+        os: [ubuntu-latest, ubuntu-24.04-arm] # windows-latest
         build_type: [Release]
-        c_compiler: [gcc, clang]
-        include:
-          - os: ubuntu-latest
-            c_compiler: gcc
-            cpp_compiler: g++
-          - os: ubuntu-latest
-            c_compiler: clang
-            cpp_compiler: clang++
-        exclude:
-          - os: ubuntu-latest
-            c_compiler: cl
+        compiler:
+            - { c: gcc,   cpp: g++ }
+            - { c: clang, cpp: clang++ }
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
@@ -48,18 +40,18 @@ jobs:
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
     - name: Install boost
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
-        sudo apt-get install -y libboost-all-dev
+        sudo apt-get install --yes -qq libboost-all-dev
 
     - name: Configure CMake Ubuntu
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu')
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }}
+        -DCMAKE_C_COMPILER=${{ matrix.compiler.c }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DATOMIC_QUEUE_BUILD_TESTS=ON
         -DATOMIC_QUEUE_BUILD_EXAMPLES=ON

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Designed with a goal to minimize the latency between one thread pushing an eleme
 
 It has been developed, tested and benchmarked on Linux. Yet, any C++14 platform implementing `std::atomic` is expected to compile the unit-tests and run them without failures just as well.
 
-The unit-tests build and succeed on Windows, but the continuous integrations hosted by GitHub are currently set up only for x86_64 platform on Ubuntu-22.04 and Ubuntu-24.04. Pull requests to extend the [continuous integrations][18] to run on other architectures and/or platforms are welcome.
+The unit-tests build and succeed on Windows, but the continuous integrations running on GitHub are currently set up only for x86_64 and arm64 platforms on ubuntu-22.04 and ubuntu-24.04. Pull requests to extend the [continuous integrations][18] to run on other architectures and/or platforms are welcome.
 
 ## Design Principles
 When minimizing latency a good design is not when there is nothing left to add, but rather when there is nothing left to remove, as these queues exemplify.


### PR DESCRIPTION
### Chores
- Add ubuntu arm to workflows
- Let dependabot update github-actions
- Make apt install less verbose
- Set editorconfig *.yaml to indent_size = 2