### PR TITLE
Modified cmake CI to also build for Windows and fixed MSVC error C3493

### DIFF
--- a/.github/workflows/cmake-gcc-clang.yml
+++ b/.github/workflows/cmake-gcc-clang.yml
@@ -35,11 +35,30 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm] # windows-latest
-        build_type: [Release]
-        compiler:
-            - { c: gcc,   cpp: g++ }
-            - { c: clang, cpp: clang++ }
+        include:
+          # --- Linux x64 ---
+          # We define 'compiler' as a dictionary (object) here
+          - os: ubuntu-latest
+            build_type: Release
+            compiler: { c: gcc, cpp: g++ }
+
+          - os: ubuntu-latest
+            build_type: Release
+            compiler: { c: clang, cpp: clang++ }
+
+          # --- Linux ARM ---
+          - os: ubuntu-24.04-arm
+            build_type: Release
+            compiler: { c: gcc, cpp: g++ }
+
+          - os: ubuntu-24.04-arm
+            build_type: Release
+            compiler: { c: clang, cpp: clang++ }
+
+          # --- Windows ---
+          - os: windows-latest
+            build_type: Release
+            compiler: { c: cl, cpp: cl }
 
     steps:
     - uses: actions/checkout@v5
@@ -56,6 +75,19 @@ jobs:
       run: |
         sudo apt-get install --yes -qq libboost-all-dev
 
+    - name: Install Boost via vcpkg (Windows)
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        # 1. Install Boost using the Microsoft Package Manager
+        # windows-latest has vcpkg pre-installed at C:\vcpkg
+        vcpkg install boost-test:x64-windows
+
+        # 2. Inform CMake where to find it
+        echo "BOOST_ROOT=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows" >> $env:GITHUB_ENV
+
+        # 3. Add vcpkg DLL path to CI before running tests
+        echo "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin" >> $env:GITHUB_PATH
+
     - name: Configure CMake Ubuntu
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
@@ -64,6 +96,15 @@ jobs:
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }}
         -DCMAKE_C_COMPILER=${{ matrix.compiler.c }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DATOMIC_QUEUE_BUILD_TESTS=ON
+        -DATOMIC_QUEUE_BUILD_EXAMPLES=ON
+        -S ${{ github.workspace }}
+
+    - name: Configure CMake Windows - MSVC
+      if: startsWith(matrix.os, 'windows') && matrix.compiler.cpp == 'cl'
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DATOMIC_QUEUE_BUILD_TESTS=ON
         -DATOMIC_QUEUE_BUILD_EXAMPLES=ON

--- a/src/example.cc
+++ b/src/example.cc
@@ -37,7 +37,7 @@ int main() {
     // Start the producers.
     std::thread producers[PRODUCERS];
     for(int i = 0; i < PRODUCERS; ++i)
-        producers[i] = std::thread([&q]() {
+        producers[i] = std::thread([&q, N = N]() {
             // Each producer pushes range [1, N] elements into the queue.
             // Ascending order [1, N] requires comparing with N at each loop iteration. Ascending order isn't necessary here.
             // Push elements in descending order, range [N, 1] with step -1, so that CPU decrement instruction sets zero/equal flag

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -43,7 +43,7 @@ void stress() {
     uint64_t results[CONSUMERS];
     std::thread consumers[CONSUMERS];
     for(unsigned i = 0; i < CONSUMERS; ++i)
-        consumers[i] = std::thread([&q, &barrier, &r = results[i]]() {
+        consumers[i] = std::thread([&q, &barrier, &r = results[i], STOP = STOP]() {
             barrier.wait();
             uint64_t result = 0;
             for(T n; (n = q.pop()) != STOP;)


### PR DESCRIPTION
Hello,

This PR updates the cmake-gcc-clang.yml workflow to add Windows (MSVC) support, while keeping the existing Linux build paths untouched.

When enabling Windows builds, MSVC failed for the lambda captures involving N and STOP with
'C3493: variable cannot be implicitly captured'

MSVC requires explicit lambda captures whenever an outer-scope identifier is referenced inside the lambda.

After adding explicit captures (e.g. [&q, N] or [&q, &N]), the Linux/Clang build started failing with:
lambda capture 'N' is not required to be captured for this use.

Clang treats constexpr variables differently: it substitutes their values during constant folding, so the lambda never actually uses the captured variable, leading to an unused-capture error (which fails the build under -Werror).

To satisfy both compilers, the lambdas now use init-capture: [q, N = N]()

This creates a runtime lambda member initialized from the outer constexpr value. This makes MSVC happy (explicit capture exists) and Clang happy (the captured variable is actually used). The same fix was applied for STOP.

With these changes, both Windows and Linux builds now pass.

This is my first PR on GitHub, and I’m looking forward to your feedback.
Have a great day.