### PR TITLE
Fix Windows CI by removing unsupported CMAKE_BUILD_TYPE usage

### DIFF
--- a/.github/workflows/cmake-gcc-clang.yml
+++ b/.github/workflows/cmake-gcc-clang.yml
@@ -105,7 +105,6 @@ jobs:
       if: startsWith(matrix.os, 'windows') && matrix.compiler.cpp == 'cl'
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DATOMIC_QUEUE_BUILD_TESTS=ON
         -DATOMIC_QUEUE_BUILD_EXAMPLES=ON
         -S ${{ github.workspace }}


### PR DESCRIPTION
Hello,

This follow-up PR removes the `-DCMAKE_BUILD_TYPE=${{ matrix.build_type }}` 
argument from the Windows CI configuration.

MSVC uses a multi-config generator, so CMAKE_BUILD_TYPE is ignored and 
produces a warning during configuration. The workflow already relies on 
`--config <type>` during the build step, which is the correct approach.

Sorry for not including this cleanup in the previous PR.