### PR TITLE
Switched Windows Boost installation from vcpkg to MarkusJx/install-boost

### DIFF
--- a/.github/workflows/cmake-gcc-clang.yml
+++ b/.github/workflows/cmake-gcc-clang.yml
@@ -70,23 +70,20 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-    - name: Install boost
+    - name: Install boost on linux
       if: startsWith(matrix.os, 'ubuntu')
       run: |
+        sudo apt-get update
         sudo apt-get install --yes -qq libboost-all-dev
 
-    - name: Install Boost via vcpkg (Windows)
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        # 1. Install Boost using the Microsoft Package Manager
-        # windows-latest has vcpkg pre-installed at C:\vcpkg
-        vcpkg install boost-test:x64-windows
-
-        # 2. Inform CMake where to find it
-        echo "BOOST_ROOT=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows" >> $env:GITHUB_ENV
-
-        # 3. Add vcpkg DLL path to CI before running tests
-        echo "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin" >> $env:GITHUB_PATH
+    - name: Install boost on windows
+      if: startsWith(matrix.os, 'windows') && matrix.compiler.cpp == 'cl'
+      uses: MarkusJx/install-boost@v2.5.1
+      id: install-boost-windows
+      with:
+        boost_version: 1.89.0
+        platform_version: 2022
+        toolset: msvc
 
     - name: Configure CMake Ubuntu
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -108,7 +105,8 @@ jobs:
         -DATOMIC_QUEUE_BUILD_TESTS=ON
         -DATOMIC_QUEUE_BUILD_EXAMPLES=ON
         -S ${{ github.workspace }}
-
+        -DBOOST_ROOT=${{steps.install-boost-windows.outputs.BOOST_ROOT}}
+  
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}


### PR DESCRIPTION
Hello @max0x7ba ,

This PR contains two CI changes.

### Windows: Replaced vcpkg with MarkusJx/install-boost action

I replaced vcpkg-based Boost installation with the MarkusJx/install-boost action for faster and more reliable Windows builds. The new action provides pre-built Boost binaries for MSVC, reducing build time by ~3 minutes and eliminating vcpkg dependency.

### Linux: Added apt-get update before installing Boost

Added `sudo apt-get update` to refresh package indexes before installing Boost on Linux. This fixes 404 errors on Ubuntu ARM where outdated package indexes were causing installation failures:

```
E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/universe/b/boost1.83/libboost-nowide1.83-dev_1.83.0-2.1ubuntu3.1_arm64.deb  404  Not Found [IP: 91.189.91.102 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Have a great day !