### PR TITLE
Resolve naming conflicts with Objective-C++

### DIFF
--- a/include/atomic_queue/atomic_queue.h
+++ b/include/atomic_queue/atomic_queue.h
@@ -144,7 +144,7 @@ ATOMIC_QUEUE_INLINE static constexpr uint64_t round_up_to_power_of_2(uint64_t a)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template<class T>
-constexpr T nil() noexcept {
+constexpr T nil_val() noexcept {
 #if __cpp_lib_atomic_is_always_lock_free // Better compile-time error message requires C++17.
     static_assert(std::atomic<T>::is_always_lock_free, "Queue element type T is not atomic. Use AtomicQueue2/AtomicQueueB2 for such element types.");
 #endif
@@ -390,7 +390,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<class T, unsigned SIZE, T NIL = details::nil<T>(), bool MINIMIZE_CONTENTION = true, bool MAXIMIZE_THROUGHPUT = true, bool TOTAL_ORDER = false, bool SPSC = false>
+template<class T, unsigned SIZE, T NIL = details::nil_val<T>(), bool MINIMIZE_CONTENTION = true, bool MAXIMIZE_THROUGHPUT = true, bool TOTAL_ORDER = false, bool SPSC = false>
 class AtomicQueue : public AtomicQueueCommon<AtomicQueue<T, SIZE, NIL, MINIMIZE_CONTENTION, MAXIMIZE_THROUGHPUT, TOTAL_ORDER, SPSC>> {
     using Base = AtomicQueueCommon<AtomicQueue<T, SIZE, NIL, MINIMIZE_CONTENTION, MAXIMIZE_THROUGHPUT, TOTAL_ORDER, SPSC>>;
     friend Base;
@@ -464,7 +464,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<class T, class A = std::allocator<T>, T NIL = details::nil<T>(), bool MAXIMIZE_THROUGHPUT = true, bool TOTAL_ORDER = false, bool SPSC = false>
+template<class T, class A = std::allocator<T>, T NIL = details::nil_val<T>(), bool MAXIMIZE_THROUGHPUT = true, bool TOTAL_ORDER = false, bool SPSC = false>
 class AtomicQueueB : private std::allocator_traits<A>::template rebind_alloc<std::atomic<T>>,
                      public AtomicQueueCommon<AtomicQueueB<T, A, NIL, MAXIMIZE_THROUGHPUT, TOTAL_ORDER, SPSC>> {
     using AllocatorElements = typename std::allocator_traits<A>::template rebind_alloc<std::atomic<T>>;


### PR DESCRIPTION
Dear @max0x7ba 

My apologies for reopening this PR.
First of all, hope you have a good day!

Although I could have just left these changes sitting quietly in my fork, I decided to try submitting a PR again.
I just hope more people will benefit from your excellent‌ work.
I completely agree with your point that one PR should focus on just one thing.
And this time I don’t want to talk about how beneficial this PR is, because I understand you might not be interested in Objective-C++ compatibility at all.
So, I’d like to talk about what side effects this PR might bring.

1. Is this a breaking api change?
`nil` is inside `details` namespace. So we don’t want users to use it, and we don’t guarantee the consistency of this, am I right? So the answer is NO.

2. Will this increase maintenance complexity?
Obviously NOT, this is a one-time change.

3. Does this violate the principle that this library was designed for C++?
IMO the answer is NO. We just achieved zero-cost compatibility with Objective-C++ while prioritizing C++ support.

Of course, I respect your decision, and I won’t submit any similar PR in the future if this one is rejected.
Finally, I still hope this PR can be merged into the upstream. 
And thank you again for your excellent work.