### PR TITLE
Add Apple Silicon support with 128-byte cache line size

### DIFF
--- a/.github/workflows/cmake-gcc-clang.yml
+++ b/.github/workflows/cmake-gcc-clang.yml
@@ -54,6 +54,11 @@ jobs:
             build_type: Release
             compiler: { c: clang, cpp: clang++ }
 
+          # --- macOS ---
+          - os: macos-latest
+            build_type: Release
+            compiler: { c: clang, cpp: clang++ }
+
           # --- Windows ---
           - os: windows-latest
             build_type: Release
@@ -75,6 +80,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install --yes -qq libboost-test-dev
 
+    - name: Install boost on macos
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        brew install boost
+
     - name: Install boost on windows
       if: startsWith(matrix.os, 'windows') && matrix.compiler.cpp == 'cl'
       uses: MarkusJx/install-boost@v2.6.0
@@ -84,10 +94,10 @@ jobs:
         platform_version: 2025
         toolset: msvc
 
-    - name: Configure CMake Ubuntu
+    - name: Configure CMake Unix (Linux/macOS)
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      if: startsWith(matrix.os, 'ubuntu')
+      if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }}

--- a/include/atomic_queue/defs.h
+++ b/include/atomic_queue/defs.h
@@ -90,7 +90,11 @@ ATOMIC_QUEUE_SINLINE void spin_loop_pause() noexcept {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__APPLE__) && defined(__aarch64__)
+constexpr int CACHE_LINE_SIZE = 128;
+#else
 constexpr int CACHE_LINE_SIZE = 64;
+#endif
 ATOMIC_QUEUE_SINLINE void spin_loop_pause() noexcept {
 #if (defined(__ARM_ARCH_6K__) || \
      defined(__ARM_ARCH_6Z__) || \


### PR DESCRIPTION
Apple's M-series (M1-M4) and A-series (A14+) use 128-byte cache lines, I use `__APPLE__` && `__aarch64__` to detect Apple Silicon and correct cache line size for alignment. I also add macOS to the CMake CI matrix to keep this supported.