### PR TITLE
Add cross-architecture continuous integrations under QEMU

### DIFF
--- a/.github/workflows/ci-cross.yml
+++ b/.github/workflows/ci-cross.yml
@@ -67,9 +67,9 @@ jobs:
 
     - name: Build the unit-tests and the example
       run: |
-        ${{ matrix.triplet }}-g++ -std=c++14 -O2 -pthread -Wall -Wextra -Iinclude -Isrc \
+        ${{ matrix.triplet }}-g++ -std=c++14 -O2 -pthread -Wall -Wextra -Wno-unused-variable -Iinclude -Isrc \
             -DBOOST_TEST_DYN_LINK=1 src/tests.cc -o tests -lboost_unit_test_framework
-        ${{ matrix.triplet }}-g++ -std=c++14 -O2 -pthread -Wall -Wextra -Iinclude -Isrc \
+        ${{ matrix.triplet }}-g++ -std=c++14 -O2 -pthread -Wall -Wextra -Wno-unused-variable -Iinclude -Isrc \
             src/example.cc -o example
         file tests example
 

--- a/.github/workflows/ci-cross.yml
+++ b/.github/workflows/ci-cross.yml
@@ -1,0 +1,80 @@
+name: Cross-architecture Continuous Integrations
+
+on:
+  push:
+    branches: [ master, maxim ]
+    paths:
+      - '!**'
+      - '**.h'
+      - '**.cc'
+      - .github/workflows/ci-cross.yml
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '!**'
+      - '**.h'
+      - '**.cc'
+      - .github/workflows/ci-cross.yml
+
+jobs:
+  unit-test:
+    name: ${{ matrix.arch }}
+    runs-on: ubuntu-24.04
+    # Debian ships Boost.Test for all these architectures from one archive, Ubuntu does not.
+    container: debian:testing
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Weakly-ordered, 128-byte cache line.
+          - arch: ppc64el
+            triplet: powerpc64le-linux-gnu
+            qemu: qemu-ppc64le
+          # Weakly-ordered, spin_loop_pause() is a hand-encoded PAUSE hint.
+          - arch: riscv64
+            triplet: riscv64-linux-gnu
+            qemu: qemu-riscv64
+          # Big-endian, 256-byte cache line, no pause instruction.
+          - arch: s390x
+            triplet: s390x-linux-gnu
+            qemu: qemu-s390x
+          # spin_loop_pause() is 8 nops.
+          - arch: loong64
+            triplet: loongarch64-linux-gnu
+            qemu: qemu-loongarch64
+
+    steps:
+    - name: Install git for actions/checkout
+      run: |
+        apt-get update
+        apt-get install --yes -qq --no-install-recommends git ca-certificates
+
+    - uses: actions/checkout@v7
+
+    - name: Install the cross-toolchain, QEMU and Boost.Test
+      run: |
+        dpkg --add-architecture ${{ matrix.arch }}
+        apt-get update
+        apt-get install --yes -qq --no-install-recommends \
+            g++-${{ matrix.triplet }} qemu-user file libboost-test-dev:${{ matrix.arch }}
+
+    - name: Toolset versions
+      run: |
+        ${{ matrix.triplet }}-g++ --version
+        ${{ matrix.qemu }} -version | head -1
+
+    - name: Build the unit-tests and the example
+      run: |
+        ${{ matrix.triplet }}-g++ -std=c++14 -O2 -pthread -Wall -Wextra -Iinclude -Isrc \
+            -DBOOST_TEST_DYN_LINK=1 src/tests.cc -o tests -lboost_unit_test_framework
+        ${{ matrix.triplet }}-g++ -std=c++14 -O2 -pthread -Wall -Wextra -Iinclude -Isrc \
+            src/example.cc -o example
+        file tests example
+
+    - name: Run the example
+      run: ${{ matrix.qemu }} ./example
+
+    - name: Run the unit-tests
+      run: ${{ matrix.qemu }} ./tests --log_level=unit_scope --report_level=short

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Makefile Continuous Integrations](https://github.com/max0x7ba/atomic_queue/actions/workflows/ci.yml/badge.svg)](https://github.com/max0x7ba/atomic_queue/actions/workflows/ci.yml)
 [![CMake Continuous Integrations](https://github.com/max0x7ba/atomic_queue/actions/workflows/cmake-gcc-clang.yml/badge.svg)](https://github.com/max0x7ba/atomic_queue/actions/workflows/cmake-gcc-clang.yml)
 [![Meson Continuous Integrations](https://github.com/max0x7ba/atomic_queue/actions/workflows/ci-meson.yml/badge.svg)](https://github.com/max0x7ba/atomic_queue/actions/workflows/ci-meson.yml)
+[![Cross-architecture Continuous Integrations](https://github.com/max0x7ba/atomic_queue/actions/workflows/ci-cross.yml/badge.svg)](https://github.com/max0x7ba/atomic_queue/actions/workflows/ci-cross.yml)
 <br>
 ![platform Linux x86_64](https://img.shields.io/badge/platform-Linux%20x86_64--bit-gold)
 ![platform Linux ARM](https://img.shields.io/badge/platform-Linux%20ARM-gold)
@@ -23,7 +24,7 @@ Designed with a goal to minimize the latency between one thread pushing an eleme
 
 It has been developed, tested and benchmarked on Linux. Yet, any C++14 platform implementing `std::atomic` is expected to compile the unit-tests and run them without failures just as well.
 
-Continuous integrations running the unit-tests on GitHub are set up for x86_64 and arm64 platforms, Ubuntu-22.04, Ubuntu-24.04 and Windows. Pull requests to extend the [continuous integrations][18] to run the unit-tests on other architectures/platforms are most welcome.
+Continuous integrations running the unit-tests on GitHub are set up for x86_64 and arm64 platforms, Ubuntu-22.04, Ubuntu-24.04 and Windows, and for loong64, ppc64el, riscv64 and s390x under QEMU user-mode emulation. Pull requests to extend the [continuous integrations][18] to run the unit-tests on other architectures/platforms are most welcome.
 
 ## Design Principles
 When minimizing latency a good design is not when there is nothing left to add, but rather when there is nothing left to remove, as these queues exemplify.


### PR DESCRIPTION
`defs.h` implements `spin_loop_pause()` and `CACHE_LINE_SIZE` for ppc64, s390x, riscv and
loongarch, but the continuous integrations build and run the tests on x86_64 and arm64
only, so those four branches are never compiled.

This adds one job per architecture. The job runs in a Debian container because Debian
serves all four architectures from a single archive and packages Boost.Test for each of
them, so enabling one is `dpkg --add-architecture` alone. The cross-toolchains build the
unit-tests and the example, and QEMU user-mode emulation runs them. Nothing is compiled
under emulation, so the whole matrix finishes in about eighty seconds.

One trade-off worth stating plainly: `debian:testing` is a rolling target, so unrelated
upstream churn can turn this job red. Ubuntu cannot replace it — no Ubuntu release has a
loong64 port, so there is no `libboost-test-dev:loong64` to link `tests.cc` against. I
also have an Ubuntu-based variant that covers ppc64el, riscv64 and s390x with the
unit-tests and loong64 with the example only; happy to switch to it if you would rather
have LTS inputs.

## Verification

Green on a fork: https://github.com/s1amese2003/atomic_queue/actions/runs/32273844744

| Architecture | Compiler | Binary | Unit-tests |
| --- | --- | --- | --- |
| ppc64el | `powerpc64le-linux-gnu-g++` 15.3.0 | ELF 64-bit LSB, 64-bit PowerPC, OpenPOWER ELF V2 ABI | 27/27, 83090 assertions |
| riscv64 | `riscv64-linux-gnu-g++` 15.3.0 | ELF 64-bit LSB, UCB RISC-V, RVC, double-float ABI | 27/27, 33938 assertions |
| s390x | `s390x-linux-gnu-g++` 15.3.0 | ELF 64-bit MSB, IBM S/390 | 27/27, 279698 assertions |
| loong64 | `loongarch64-linux-gnu-g++` 16.1.0 | ELF 64-bit LSB, LoongArch | 27/27, 33938 assertions |

QEMU 11.0.3 throughout. The same four builds were also run locally in a Debian forky
container and produced identical assertion counts.
